### PR TITLE
feat!: output to file by default

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -23,4 +23,4 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test:generate-dashboard
-      - run: gh issue edit ${{ env.ISSUE_NUMBER }} --body-file ./dashboard.md
+      - run: gh issue edit ${{ env.ISSUE_NUMBER }} --body-file ./test-dashboard.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test:generate-dashboard
-      - run: cat dashboard.md | tee -a $GITHUB_STEP_SUMMARY
+      - run: cat test-dashboard.md | tee -a $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ yarn-error.log*
 
 # testing
 coverage/
-/dashboard.md
+/test-dashboard.md
 
 # artifacts
 lib/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const config = {
 module.exports = config;
 ```
 
-Run jest and the markdown output is printed to stdout.
+Run jest and the markdown dashboard is generated to `test-dashboard.md`.
 
 ### With options
 
@@ -85,7 +85,7 @@ jest --config=./jest.print-dashboard.js
 | Name                   | Type                | Default                     | Description                                                                                                                 |
 | ---------------------- | ------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `title`                | `string`            | `"Test Dashboard"`          | The title of a dashboard.<br>It will be printed at the top of the markdown output.                                          |
-| `outputPath`           | `string`            | `undefined`                 | The file path to output dashboard. If this option is specified, dashboard is printed to the file instead of stdout.         |
+| `outputPath`           | `string`            | `test-dashboard.md`         | The file path to output dashboard. If you want to output to stdout, specify `-`.                                            |
 | `permalink`            | `object` or `false` | `{(followings)}`            | Override permalink generation.<br>Set `false` to disable generation.                                                        |
 | `permalink.hostname`   | `string`            | `"github.com"`              | The hostname of permalink.<br>Specify if you using services other than github.com.<br>e.g. GitHub Enterprise or GitLab      |
 | `permalink.repository` | `string`            | `${GITHUB_REPOSITORY}`      | The repository name of permalink. (`"<owner>/<repo>"`)                                                                      |

--- a/jest.generate-dashboard.config.js
+++ b/jest.generate-dashboard.config.js
@@ -3,6 +3,6 @@ import baseConfig from "./jest.config.js";
 /** @type {import('@jest/types').Config.InitialOptions} */
 const config = {
   ...baseConfig,
-  reporters: ["default", ["jest-md-dashboard", { outputPath: "dashboard.md" }]],
+  reporters: ["default", "jest-md-dashboard"],
 };
 export default config;

--- a/src/__tests__/options.test.ts
+++ b/src/__tests__/options.test.ts
@@ -1,4 +1,4 @@
-import { buildTitle, buildPermalink } from "../options.js";
+import { buildTitle, buildOutputPath, buildPermalink } from "../options.js";
 
 describe("buildTitle", () => {
   it("should return default value", () => {
@@ -6,6 +6,17 @@ describe("buildTitle", () => {
   });
   it("should return input value", () => {
     expect(buildTitle("My dashboard")).toBe("My dashboard");
+  });
+});
+
+describe("buildOutputPath", () => {
+  it("should return default value", () => {
+    expect(buildOutputPath()).toBe("test-dashboard.md");
+  });
+  it("should return input value", () => {
+    expect(buildOutputPath("/path/to/dashboard.md")).toBe(
+      "/path/to/dashboard.md"
+    );
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   convertResultsToDashboard,
   printDashBoard,
 } from "./dashboard/index.js";
-import { buildTitle, buildPermalink } from "./options.js";
+import { buildTitle, buildPermalink, buildOutputPath } from "./options.js";
 
 export type ReporterOptions = {
   title?: string;
@@ -29,7 +29,7 @@ export class MarkdownDashboardReporter implements Reporter {
   private readonly globalConfig: Config.GlobalConfig;
   private readonly context: ReporterContext;
   private readonly title: string;
-  private readonly outputPath?: string;
+  private readonly outputPath: string;
   private readonly permalink?: Permalink;
 
   constructor(
@@ -41,7 +41,7 @@ export class MarkdownDashboardReporter implements Reporter {
     this.context = reporterContext;
 
     this.title = buildTitle(reporterOptions.title);
-    this.outputPath = reporterOptions.outputPath;
+    this.outputPath = buildOutputPath(reporterOptions.outputPath);
     this.permalink = buildPermalink(reporterOptions.permalink);
   }
 
@@ -62,13 +62,13 @@ export class MarkdownDashboardReporter implements Reporter {
       permalink: this.permalink,
     });
     const resultText = printDashBoard(dashboard);
-    if (this.outputPath !== undefined && this.outputPath.length > 0) {
+    if (this.outputPath === "-") {
+      console.log(resultText);
+    } else {
       const absolutePath = path.resolve(this.outputPath);
       await fs.mkdir(path.dirname(absolutePath), { recursive: true });
       await fs.writeFile(absolutePath, resultText);
       console.log(`\nDashboard is generated to ${absolutePath}`);
-    } else {
-      console.log(resultText);
     }
   }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,10 @@ export const buildTitle = (title?: string): string => {
   return title ?? "Test Dashboard";
 };
 
+export const buildOutputPath = (outputPath?: string): string => {
+  return outputPath ?? "test-dashboard.md";
+};
+
 export const buildPermalink = (
   permalink?: ReporterOptions["permalink"]
 ): Permalink | undefined => {


### PR DESCRIPTION
## Why

Because users generate a dashboard to file in most cases. (not to stdout)

## What

- [x] Generate `test-dashboard.md` by default
- [x] outputPath option to customize dashboard file path
  - [x] If outputPath is `-`, print to stdout
- [x] fix tests
- [x] update document