### PR TITLE
feat!: remove `permalink` option and add `permalinkBaseUrl`

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -24,3 +24,4 @@ jobs:
       - run: yarn build
       - run: yarn test:generate-dashboard
       - run: gh issue edit ${{ env.ISSUE_NUMBER }} --body-file ./test-dashboard.md
+        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,4 @@ jobs:
       - run: yarn build
       - run: yarn test:generate-dashboard
       - run: cat test-dashboard.md | tee -a $GITHUB_STEP_SUMMARY
+        if: always()

--- a/README.md
+++ b/README.md
@@ -82,15 +82,39 @@ jest --config=./jest.print-dashboard.js
 
 ## Options
 
-| Name                   | Type                | Default                     | Description                                                                                                                 |
-| ---------------------- | ------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `title`                | `string`            | `"Test Dashboard"`          | The title of a dashboard.<br>It will be printed at the top of the markdown output.                                          |
-| `outputPath`           | `string`            | `test-dashboard.md`         | The file path to output dashboard. If you want to output to stdout, specify `-`.                                            |
-| `permalink`            | `object` or `false` | `{(followings)}`            | Override permalink generation.<br>Set `false` to disable generation.                                                        |
-| `permalink.hostname`   | `string`            | `"github.com"`              | The hostname of permalink.<br>Specify if you using services other than github.com.<br>e.g. GitHub Enterprise or GitLab      |
-| `permalink.repository` | `string`            | `${GITHUB_REPOSITORY}`      | The repository name of permalink. (`"<owner>/<repo>"`)                                                                      |
-| `permalink.commit`     | `string`            | `${GITHUB_SHA}` ?? `"main"` | The commit hash of permalink.<br>You can also specify branch or tag.                                                        |
-| `permalink.pattern`    | `string`            | see description             | The template pattern of permalink.<br>Absence defaults to `"https://${hostname}/${repository}/blob/${commit}/${filePath}"`. |
+| Name               | Type     | Default             | Description                                                                                                                                                                                                                                             |
+| ------------------ | -------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`            | `string` | `"Test Dashboard"`  | The title of a dashboard.<br>It will be printed at the top of the markdown output.                                                                                                                                                                      |
+| `outputPath`       | `string` | `test-dashboard.md` | The file path to output dashboard. If you want to output to stdout, specify `-`.                                                                                                                                                                        |
+| `permalinkBaseUrl` | `string` | `undefined`         | Override baseUrl of permalink. Specify if generated permalinks are incorrect.<br>URL must have trailing slash.<br>e.g. `https://github.com/mshrtsr/jest-md-dashboard/blob/` <br>See [Permalink generation](#Permalink generation) for more information. |
+
+## Permalink generation
+
+jest-md-dashboard generates permalink to test files on GitHub (or other services) by default.
+
+jest-md-dashboard tries to find git information from the following sources.
+
+1. `permalinkBaseUrl` option
+2. (on GitHub Actions) environment variables
+3. (in git repository) git config
+
+### `permalinkBaseUrl` option
+
+If `permalinkBaseUrl` is specified on jest config, jest-md-dashboard generates permalink using it.
+
+### on GitHub Actions
+
+If you run jest on GitHub Actions, jest-md-dashboard generates permalink using the following environment variables.
+
+- `$GITHUB_ACTIONS`
+- `$GITHUB_SERVER_URL`
+- `$GITHUB_REPOSITORY`
+- `$GITHUB_SHA`
+- `$GITHUB_WORKSPACE`
+
+### in git repository
+
+If jest runs in a git repository, jest-md-dashboard generates permalink using git config of the local repository.
 
 ## Contribution
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "fix:md": "run-s 'lint:md --write'",
     "clean": "rimraf lib"
   },
-  "dependencies": {},
+  "dependencies": {
+    "isomorphic-git": "^1.18.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/preset-env": "^7.18.6",

--- a/src/__tests__/fixtures/expected.md
+++ b/src/__tests__/fixtures/expected.md
@@ -10,7 +10,7 @@
 |Test Suites|2|0|-|2|
 |Tests|17|0|1|18|
 
-## src/__tests__/fixtures/sample-1.test.ts
+## src/__tests__/fixtures/sample-1.test.ts [[link](https://github.com/mshrtsr:jest-md-dashboard/blob/main/src/__tests__/fixtures/sample-1.test.ts)]
 - describe depth 1
   - test 1
   - test 2
@@ -30,7 +30,7 @@
   - parametarized: 2
   - parametarized: 1
   - parametarized: 2
-## src/__tests__/fixtures/sample-2.test.ts
+## src/__tests__/fixtures/sample-2.test.ts [[link](https://github.com/mshrtsr:jest-md-dashboard/blob/main/src/__tests__/fixtures/sample-2.test.ts)]
 - describe depth 1
   - test 1
   - test 2

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -1,0 +1,33 @@
+import { parseRemoteUrl } from "../git.js";
+
+describe("parseRemoteUrl", () => {
+  it("should return correctly (HTTPS)", () => {
+    const url = "https://github.com/USERNAME/REPOSITORY.git";
+    const expected = {
+      serverUrl: "https://github.com",
+      repository: "USERNAME/REPOSITORY",
+    };
+    const actual = parseRemoteUrl(url);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should return correctly (HTTP)", () => {
+    const url = "http://github.example.com/USERNAME/REPOSITORY.git";
+    const expected = {
+      serverUrl: "http://github.example.com",
+      repository: "USERNAME/REPOSITORY",
+    };
+    const actual = parseRemoteUrl(url);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should return correctly (SSH)", () => {
+    const url = "git@github.com:USERNAME/REPOSITORY.git";
+    const expected = {
+      serverUrl: "https://github.com",
+      repository: "USERNAME/REPOSITORY",
+    };
+    const actual = parseRemoteUrl(url);
+    expect(actual).toStrictEqual(expected);
+  });
+});

--- a/src/__tests__/helpers/command.ts
+++ b/src/__tests__/helpers/command.ts
@@ -6,7 +6,15 @@ export const runJest = (configPath: string, env?: object) => {
   return child_process.spawnSync(jestCommand, [`--config=${configPath}`], {
     env: {
       ...process.env,
-      ...(env ? env : { GITHUB_REPOSITORY: undefined, GITHUB_SHA: undefined }),
+      ...(env
+        ? env
+        : {
+            GITHUB_ACTIONS: undefined,
+            GITHUB_SERVER_URL: undefined,
+            GITHUB_REPOSITORY: undefined,
+            GITHUB_SHA: undefined,
+            GITHUB_WORKSPACE: undefined,
+          }),
     },
   });
 };

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -6,13 +6,22 @@ import { runJest } from "./helpers/command.js";
 const jestConfig = path.resolve(__dirname, "fixtures", "jest.config.cjs");
 const expectedPath = path.resolve(__dirname, "fixtures", "expected.md");
 const outputPath = path.resolve(__dirname, "fixtures", "dist", "dashboard.md");
+const rootDir = path.resolve(__dirname, "..", "..");
+
+const env = {
+  GITHUB_ACTIONS: "true",
+  GITHUB_SERVER_URL: "https://github.com",
+  GITHUB_REPOSITORY: "mshrtsr:jest-md-dashboard",
+  GITHUB_SHA: "main",
+  GITHUB_WORKSPACE: rootDir,
+};
 
 describe("jest-md-dashboard", () => {
   beforeAll(async () => {
     await fs.rm(path.dirname(outputPath), { recursive: true, force: true });
   });
   it("can print dashboard to a file", async () => {
-    const result = runJest(jestConfig);
+    const result = runJest(jestConfig, env);
 
     const stderr = result.stderr.toString();
     if (stderr.length > 0) {

--- a/src/dashboard/__tests__/converter.test.ts
+++ b/src/dashboard/__tests__/converter.test.ts
@@ -1,4 +1,6 @@
-import { buildPermalink } from "../../options.js";
+import { jest } from "@jest/globals";
+
+import { buildPermalinkBaseUrl } from "../../options.js";
 import { convertResultsToDashboard } from "../converter.js";
 
 import { dashboard as expected } from "./fixtures/converter/expected-dashboard.js";
@@ -10,11 +12,8 @@ delete process.env.GITHUB_SHA;
 
 const baseOptions = {
   title: "My Dashboard",
-  rootPath: "/path/to/rootDir/",
-  permalink: buildPermalink({
-    repository: "mshrtsr/jest-md-dashboard",
-    commit: "main",
-  }),
+  jestRootDir: "/path/to/rootDir/",
+  permalinkBaseUrl: "https://github.com/mshrtsr/jest-md-dashboard/blob/main/",
 };
 
 describe("convertResultsToDashboard", () => {
@@ -25,7 +24,7 @@ describe("convertResultsToDashboard", () => {
   afterEach(() => {
     jest.useRealTimers();
   });
-  it("should convert results to dashboard", function () {
+  it("should convert results to dashboard", () => {
     const actual = convertResultsToDashboard(results, { ...baseOptions });
     actual.summary.totalRunTime = testDuration;
     expect(actual).toStrictEqual(expected);

--- a/src/dashboard/__tests__/printer.test.ts
+++ b/src/dashboard/__tests__/printer.test.ts
@@ -19,12 +19,12 @@ const noPermalinkExpected = fs.readFileSync(
 );
 
 describe("printDashBoard", () => {
-  it("should print dashboard correctly", function () {
+  it("should print dashboard correctly", () => {
     const actual = printDashBoard(dashboard);
     expect(actual).toBe(expected);
   });
 
-  it("should print dashboard without permalink", function () {
+  it("should print dashboard without permalink", () => {
     const actual = printDashBoard(noPermalinkDashboard);
     expect(actual).toBe(noPermalinkExpected);
   });

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -1,5 +1,4 @@
 export type { Dashboard, Summary, TestFile, Describe, Test } from "./types.js";
 
 export { convertResultsToDashboard } from "./converter.js";
-export type { Permalink } from "./converter.js";
 export { printDashBoard } from "./printer.js";

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -1,5 +1,3 @@
-import { SnapshotSummary, TestResult } from "@jest/test-result";
-
 export type Dashboard = {
   title: string;
   summary: Summary;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,26 @@
+export const parseRemoteUrl = (
+  url: string
+): { serverUrl: string; repository: string } => {
+  // HTTPS or HTTP (e.g. https://github.com/USERNAME/REPOSITORY.git)
+  if (url.startsWith("https://") || url.startsWith("http://")) {
+    const _url = new URL(url);
+    const serverUrl = _url.origin;
+    const repository = _url.pathname.match(/\/([^/]+\/[^/]+).git$/)?.at(1);
+    if (repository === undefined) {
+      throw new Error(`cannot parse repository from URL: ${url}`);
+    }
+    return { serverUrl, repository };
+  }
+
+  // SSH (e.g. git@github.com:USERNAME/REPOSITORY.git)
+  const matched = url.match(/git@(.+):([^/]+\/[^/]+).git/);
+  const hostname = matched?.at(1);
+  const repository = matched?.at(2);
+  if (hostname === undefined) {
+    throw new Error(`cannot parse hostname from URL: ${url}`);
+  }
+  if (repository === undefined) {
+    throw new Error(`cannot parse repository from URL: ${url}`);
+  }
+  return { serverUrl: `https://${hostname}`, repository };
+};

--- a/src/git.ts
+++ b/src/git.ts
@@ -5,7 +5,9 @@ export const parseRemoteUrl = (
   if (url.startsWith("https://") || url.startsWith("http://")) {
     const _url = new URL(url);
     const serverUrl = _url.origin;
-    const repository = _url.pathname.match(/\/([^/]+\/[^/]+).git$/)?.at(1);
+    const matched = _url.pathname.match(/\/([^/]+\/[^/]+).git$/);
+    const repository =
+      matched !== null && matched.length >= 1 ? matched[1] : undefined;
     if (repository === undefined) {
       throw new Error(`cannot parse repository from URL: ${url}`);
     }
@@ -14,8 +16,10 @@ export const parseRemoteUrl = (
 
   // SSH (e.g. git@github.com:USERNAME/REPOSITORY.git)
   const matched = url.match(/git@(.+):([^/]+\/[^/]+).git/);
-  const hostname = matched?.at(1);
-  const repository = matched?.at(2);
+  const hostname =
+    matched !== null && matched.length >= 2 ? matched[1] : undefined;
+  const repository =
+    matched !== null && matched.length >= 2 ? matched[2] : undefined;
   if (hostname === undefined) {
     throw new Error(`cannot parse hostname from URL: ${url}`);
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -58,11 +58,11 @@ export const buildPermalinkBaseUrl = async ({
 
   try {
     const remotes = await git.listRemotes({ fs, dir: rootDir });
-    const remote = remotes.at(0);
-    if (remote === undefined) {
+    if (remotes.length === 0) {
       console.error("no remote URL found.");
       return undefined;
     }
+    const remote = remotes[0];
     const { serverUrl, repository } = parseRemoteUrl(remote.url);
     const commit = await git.resolveRef({ fs, dir: rootDir, ref: "HEAD" });
     const subtree = path.relative(rootDir, jestRootDir);

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,9 @@
-import { Permalink } from "./dashboard/index.js";
+import fs from "fs";
+import path from "path";
+
+import git from "isomorphic-git";
+
+import { parseRemoteUrl } from "./git.js";
 
 import { ReporterOptions } from "./index.js";
 
@@ -10,32 +15,62 @@ export const buildOutputPath = (outputPath?: string): string => {
   return outputPath ?? "test-dashboard.md";
 };
 
-export const buildPermalink = (
-  permalink?: ReporterOptions["permalink"]
-): Permalink | undefined => {
-  if (
-    permalink !== undefined &&
-    typeof permalink !== "boolean" &&
-    typeof permalink !== "object"
-  ) {
-    throw new Error("`permalink` option must be object or boolean");
+export const buildPermalinkBaseUrl = async ({
+  permalinkBaseUrl,
+  jestRootDir,
+}: {
+  permalinkBaseUrl?: ReporterOptions["permalinkBaseUrl"];
+  jestRootDir: string;
+}): Promise<string | undefined> => {
+  if (permalinkBaseUrl) {
+    return permalinkBaseUrl;
   }
 
-  let hostname = "github.com";
-  let repository = process.env.GITHUB_REPOSITORY;
-  let commit = process.env.GITHUB_SHA ?? "main";
-  // eslint-disable-next-line no-template-curly-in-string
-  let pattern = "https://${hostname}/${repository}/blob/${commit}/${filePath}";
+  if (process.env.GITHUB_ACTIONS) {
+    if (
+      !process.env.GITHUB_SERVER_URL ||
+      !process.env.GITHUB_REPOSITORY ||
+      !process.env.GITHUB_SHA ||
+      !process.env.GITHUB_WORKSPACE
+    ) {
+      throw new Error(
+        "The following environment variables are required for the GitHub Actions environment\n- GITHUB_SERVER_URL\n- GITHUB_REPOSITORY\n- GITHUB_SHA\n- GITHUB_WORKSPACE"
+      );
+    }
+    const serverUrl = process.env.GITHUB_SERVER_URL;
+    const repository = process.env.GITHUB_REPOSITORY;
+    const commit = process.env.GITHUB_SHA;
+    const rootDir = process.env.GITHUB_WORKSPACE;
+    const subtree = path.relative(rootDir, jestRootDir);
+    const trailingSlash =
+      subtree.length > 0 && !subtree.endsWith("/") ? "/" : "";
+    return `${serverUrl}/${repository}/blob/${commit}/${subtree}${trailingSlash}`;
+  }
 
-  if (typeof permalink === "boolean" && !permalink) return undefined;
-  if (typeof permalink === "object" && permalink !== null) {
-    if (permalink.hostname) hostname = permalink.hostname;
-    if (permalink.repository) repository = permalink.repository;
-    if (permalink.commit) commit = permalink.commit;
-    if (permalink.pattern) pattern = permalink.pattern;
+  const rootDir = await git
+    .findRoot({ fs, filepath: jestRootDir })
+    .then((dir) => dir)
+    .catch(async () => undefined);
+  if (rootDir === undefined) {
+    console.log("permalink disabled because project is not a git repository");
+    return undefined;
   }
-  if (hostname && repository && commit && pattern) {
-    return { hostname, repository, commit, pattern };
+
+  try {
+    const remotes = await git.listRemotes({ fs, dir: rootDir });
+    const remote = remotes.at(0);
+    if (remote === undefined) {
+      console.error("no remote URL found.");
+      return undefined;
+    }
+    const { serverUrl, repository } = parseRemoteUrl(remote.url);
+    const commit = await git.resolveRef({ fs, dir: rootDir, ref: "HEAD" });
+    const subtree = path.relative(rootDir, jestRootDir);
+    const trailingSlash =
+      subtree.length > 0 && !subtree.endsWith("/") ? "/" : "";
+    return `${serverUrl}/${repository}/blob/${commit}/${subtree}${trailingSlash}`;
+  } catch (e) {
+    console.error(e);
+    return undefined;
   }
-  return undefined;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+async-lock@^1.1.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.3.2.tgz#56668613f91c1c55432b4db73e65c9ced664e789"
+  integrity sha512-phnXdS3RP7PPcmP6NWWzWMU0sLTeyvtZCxBPpZdkYE3seGLKSQZs9FrmVO/qwypq98FUtWWUEYxziLkdGk5nnA==
+
 async-retry@^1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
@@ -2364,6 +2369,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+clean-git-ref@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/clean-git-ref/-/clean-git-ref-2.0.1.tgz#dcc0ca093b90e527e67adb5a5e55b1af6816dcd9"
+  integrity sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -2500,6 +2510,11 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+crc-32@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -2580,6 +2595,13 @@ decamelize@^1.1.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -2637,6 +2659,11 @@ diff-sequences@^28.1.1:
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
   integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
+
+diff3@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/diff3/-/diff3-0.0.3.tgz#d4e5c3a4cdf4e5fe1211ab42e693fcb4321580fc"
+  integrity sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==
 
 diff@^5.0.0:
   version "5.1.0"
@@ -3468,7 +3495,7 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ignore@^5.1.1, ignore@^5.2.0:
+ignore@^5.1.1, ignore@^5.1.4, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -3507,7 +3534,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3683,6 +3710,23 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isomorphic-git@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.18.3.tgz#b2ef91688ac8f4315a8f3ce72f24a76c17bf61ad"
+  integrity sha512-CVTNt0uU5RQ4g626LxqUyShdoeD15uZppKA0tk7iY/PyikCbRG594a7BksU4JZcOC6RsqUkURdIlFyKhAfdbqg==
+  dependencies:
+    async-lock "^1.1.0"
+    clean-git-ref "^2.0.1"
+    crc-32 "^1.2.0"
+    diff3 "0.0.3"
+    ignore "^5.1.4"
+    minimisted "^2.0.0"
+    pako "^1.0.10"
+    pify "^4.0.1"
+    readable-stream "^3.4.0"
+    sha.js "^2.4.9"
+    simple-get "^4.0.1"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -4370,6 +4414,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -4395,6 +4444,13 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+minimisted@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/minimisted/-/minimisted-2.0.1.tgz#d059fb905beecf0774bc3b308468699709805cb1"
+  integrity sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==
+  dependencies:
+    minimist "^1.2.5"
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -4594,7 +4650,7 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -4698,6 +4754,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^1.0.10:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -4925,7 +4986,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@3:
+readable-stream@3, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5135,15 +5196,15 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
@@ -5171,6 +5232,14 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+sha.js@^2.4.9:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -5214,6 +5283,20 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Why

Because `permalink` is too complicated.
Also, I want to use permalink with zero configuration on common use cases.

## What

- [x] remove `permalink` option
- [x] add `permalinkBaseUrl` option
- [x] build `permalinkBaseUrl` with zero configuration
  - from GitHub Actions environment variables
  - from local git config
- [x] add and fix tests
- [x] update documents