### PR TITLE
Test results sorted alphabetically by file path

### DIFF
--- a/src/dashboard/__tests__/fixtures/converter/expected-dashboard.ts
+++ b/src/dashboard/__tests__/fixtures/converter/expected-dashboard.ts
@@ -3,6 +3,28 @@ import { testDuration, testStartTime } from "../../helpers/datetime.js";
 
 const testFiles: TestFile[] = [
   {
+    filePath: "src/__tests__/sample-2.test.ts",
+    permalink:
+      "https://github.com/mshrtsr/jest-md-dashboard/blob/main/src/__tests__/sample-2.test.ts",
+    numPassingTests: 4,
+    numFailingTests: 0,
+    numTodoTests: 0,
+    duration: 3.869,
+    children: [
+      {
+        type: "describe",
+        describe: "describe depth 1",
+        status: "passed",
+        children: [
+          { type: "test", title: "test 1", status: "passed" },
+          { type: "test", title: "test 2", status: "passed" },
+          { type: "test", title: "test 3", status: "passed" },
+          { type: "test", title: "test 4", status: "passed" },
+        ],
+      },
+    ],
+  },
+  {
     filePath: "src/__tests__/sample-1.test.ts",
     permalink:
       "https://github.com/mshrtsr/jest-md-dashboard/blob/main/src/__tests__/sample-1.test.ts",
@@ -61,29 +83,7 @@ const testFiles: TestFile[] = [
         ],
       },
     ],
-  },
-  {
-    filePath: "src/__tests__/sample-2.test.ts",
-    permalink:
-      "https://github.com/mshrtsr/jest-md-dashboard/blob/main/src/__tests__/sample-2.test.ts",
-    numPassingTests: 4,
-    numFailingTests: 0,
-    numTodoTests: 0,
-    duration: 3.869,
-    children: [
-      {
-        type: "describe",
-        describe: "describe depth 1",
-        status: "passed",
-        children: [
-          { type: "test", title: "test 1", status: "passed" },
-          { type: "test", title: "test 2", status: "passed" },
-          { type: "test", title: "test 3", status: "passed" },
-          { type: "test", title: "test 4", status: "passed" },
-        ],
-      },
-    ],
-  },
+  }
 ];
 
 export const dashboard: Dashboard = {

--- a/src/dashboard/converter.ts
+++ b/src/dashboard/converter.ts
@@ -18,6 +18,9 @@ export const convertResultsToDashboard = (
   }
 ): Dashboard => {
   const summary = convertSummary(results);
+  results.testResults.sort((a, b) =>
+    b.testFilePath.localeCompare(a.testFilePath)
+  );
   const testFiles: TestFile[] = results.testResults.map((resultByFile) =>
     convertTestFile(resultByFile, {
       jestRootDir: options.jestRootDir,


### PR DESCRIPTION
## Why

So far, the order of test results is indefinite. (remains as is sent from the Jest.)
It is better to sort test results for better visibility.

## What

- [x] sort test results alphabetically by file path
- [x] fix tests
